### PR TITLE
修复遗漏的签名密钥配置硬编码

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -101,6 +101,7 @@ jobs:
       env:
         KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
         KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
+        KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
       run: ./gradlew assembleRelease
 
     - name: Upload APK to release

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -35,7 +35,7 @@ android {
         create("release") {
             storeFile = file("${rootProject.projectDir}/jks/.jks")
             storePassword = System.getenv("KEYSTORE_PASSWORD") ?: "BADDDD"
-            keyAlias = "key0"
+            keyAlias = System.getenv("KEY_ALIAS") ?: "key0"
             keyPassword = System.getenv("KEY_PASSWORD") ?: "BADDDD"
         }
     }


### PR DESCRIPTION
将最后遗漏的、仍写死在代码中的签名密钥配置（密钥别名）改为能够从 secrets 读取，
以方便开发者能够自行设置密钥